### PR TITLE
Fix concept map component default result

### DIFF
--- a/MAS/app/conceptmap_component.py
+++ b/MAS/app/conceptmap_component.py
@@ -50,7 +50,12 @@ def conceptmap_component(
 
     cm_data = cm_data or {}
     return _conceptmap(
-        cm_data=cm_data, submit_request=submit_request, key=key, default=None
+        cm_data=cm_data,
+        submit_request=submit_request,
+        key=key,
+        # Return an empty structure instead of ``None`` so the component
+        # reports a valid result even before user interaction.
+        default={"elements": []},
     )
 
 


### PR DESCRIPTION
## Summary
- Return an empty structure by default in `conceptmap_component` to avoid None responses before user interaction

## Testing
- `python -m py_compile MAS/app/conceptmap_component.py MAS/app/test_component.py`
- `streamlit run MAS/app/test_component.py --server.headless true --server.port 8501`

------
https://chatgpt.com/codex/tasks/task_e_68920d7d388083229ce4f4ca1b7e6d48