### PR TITLE
fix: handle string entries in concept map elements

### DIFF
--- a/MAS/app/app.py
+++ b/MAS/app/app.py
@@ -609,8 +609,9 @@ def handle_response(response):
     # --- Real-time logging of node and edge creations ---
     if response and isinstance(response, dict) and "elements" in response:
         elements = response["elements"]
-        current_nodes = {e["data"]["id"] for e in elements if "source" not in e.get("data", {})}
-        current_edges = {e["data"]["id"] for e in elements if "source" in e.get("data", {})}
+        dict_elements = [e for e in elements if isinstance(e, dict)]
+        current_nodes = {e["data"]["id"] for e in dict_elements if "source" not in e.get("data", {})}
+        current_edges = {e["data"]["id"] for e in dict_elements if "source" in e.get("data", {})}
 
         prev_nodes = st.session_state.get("_prev_cm_nodes")
         prev_edges = st.session_state.get("_prev_cm_edges")
@@ -624,13 +625,21 @@ def handle_response(response):
             new_edges = current_edges - prev_edges
 
             for node_id in new_nodes:
-                node_data = next(e["data"] for e in elements if e["data"]["id"] == node_id)
+                node_data = next(
+                    e["data"]
+                    for e in dict_elements
+                    if e.get("data", {}).get("id") == node_id
+                )
                 print(
                     f"🆕 Node created: {node_data.get('label', '')} (id: {node_id}, x: {node_data.get('x')}, y: {node_data.get('y')})"
                 )
 
             for edge_id in new_edges:
-                edge_data = next(e["data"] for e in elements if e["data"]["id"] == edge_id)
+                edge_data = next(
+                    e["data"]
+                    for e in dict_elements
+                    if e.get("data", {}).get("id") == edge_id
+                )
                 print(
                     f"🆕 Edge created: {edge_data.get('source')} -> {edge_data.get('target')} "
                     f"(label: {edge_data.get('label', '')}, id: {edge_id})"
@@ -675,18 +684,19 @@ def handle_response(response):
         
         # Debug: Show what we're storing
         if isinstance(response, dict) and "elements" in response:
-            element_count = len(response["elements"])
+            dict_elements = [e for e in response["elements"] if isinstance(e, dict)]
+            element_count = len(dict_elements)
             st.success(f"✅ Concept map data captured: {element_count} elements")
-            
+
             # Show element breakdown
-            nodes = [e for e in response["elements"] if "source" not in e.get("data", {})]
-            edges = [e for e in response["elements"] if "source" in e.get("data", {})]
+            nodes = [e for e in dict_elements if "source" not in e.get("data", {})]
+            edges = [e for e in dict_elements if "source" in e.get("data", {})]
             st.write(f"**Elements breakdown:** {len(nodes)} nodes, {len(edges)} edges")
-            
+
             # Show first few elements for verification
-            if len(response["elements"]) > 0:
+            if len(dict_elements) > 0:
                 st.write("**Sample elements:**")
-                for i, elem in enumerate(response["elements"][:3]):
+                for i, elem in enumerate(dict_elements[:3]):
                     st.write(f"  {i+1}. {elem}")
         else:
             st.warning("⚠️ Response received but no elements found")


### PR DESCRIPTION
## Summary
- avoid AttributeError when concept map elements include strings by filtering dict elements
- update element breakdown to consider only valid concept map entries

## Testing
- `python -m pytest`
- `streamlit run app/app.py` (startup verified)

------
https://chatgpt.com/codex/tasks/task_e_6892357d25c88322b4b7894c219f1c76