### PR TITLE
Ensure concept map debug logs are saved to session log file

### DIFF
--- a/MAS/app/app.py
+++ b/MAS/app/app.py
@@ -1,9 +1,13 @@
 import json
 import os
 import copy
+import logging
 import streamlit as st
 from conceptmap_component import conceptmap_component, parse_conceptmap
 from streamlit_experimental_session import StreamlitExperimentalSession
+
+
+logger = logging.getLogger(__name__)
 
 
 # Session State Initialization
@@ -593,18 +597,18 @@ def render_followup():
 def handle_response(response):
     """Handle concept map response with cumulative logic and enhanced debugging."""
     # Always log what we receive, even if None
-    print(f"🔍 HANDLE_RESPONSE DEBUG:")
-    print(f"   Response received: {response is not None}")
-    print(f"   Response type: {type(response).__name__}")
-    print(f"   Followup state: {st.session_state.followup}")
-    print(f"   Submit request: {st.session_state.submit_request}")
+    logger.debug("🔍 HANDLE_RESPONSE DEBUG:")
+    logger.debug(f"   Response received: {response is not None}")
+    logger.debug(f"   Response type: {type(response).__name__}")
+    logger.debug(f"   Followup state: {st.session_state.followup}")
+    logger.debug(f"   Submit request: {st.session_state.submit_request}")
 
     if response is not None:
-        print(f"   Response content: {str(response)[:300]}")
+        logger.debug(f"   Response content: {str(response)[:300]}")
         if isinstance(response, dict):
-            print(f"   Has elements: {'elements' in response}")
+            logger.debug(f"   Has elements: {'elements' in response}")
             if "elements" in response:
-                print(f"   Elements count: {len(response['elements'])}")
+                logger.debug(f"   Elements count: {len(response['elements'])}")
 
     # --- Real-time logging of node and edge creations ---
     if response and isinstance(response, dict) and "elements" in response:
@@ -633,7 +637,7 @@ def handle_response(response):
                     for e in dict_elements
                     if e.get("data", {}).get("id") == node_id
                 )
-                print(
+                logger.info(
                     f"🆕 Node created: {node_data.get('label', '')} (id: {node_id}, x: {node_data.get('x')}, y: {node_data.get('y')})"
                 )
                 if (
@@ -656,7 +660,7 @@ def handle_response(response):
                     for e in dict_elements
                     if e.get("data", {}).get("id") == edge_id
                 )
-                print(
+                logger.info(
                     f"🆕 Edge created: {edge_data.get('source')} -> {edge_data.get('target')} "
                     f"(label: {edge_data.get('label', '')}, id: {edge_id})"
                 )
@@ -679,7 +683,7 @@ def handle_response(response):
             st.session_state._prev_cm_edges = current_edges
     
     if st.session_state.submit_request and response and not st.session_state.followup:
-        print(f"   ✅ Processing response...")
+        logger.info("   ✅ Processing response...")
         
         # Debug: Log what we received
         if st.session_state.experimental_session and st.session_state.experimental_session.session_logger:
@@ -709,7 +713,7 @@ def handle_response(response):
         
         # Update the current round's concept map with the new data
         st.session_state.cmdata[roundn] = response
-        print(f"   📝 Stored response in cmdata[{roundn}]")
+        logger.info(f"   📝 Stored response in cmdata[{roundn}]")
         
         # Debug: Show what we're storing
         if isinstance(response, dict) and "elements" in response:
@@ -738,10 +742,12 @@ def handle_response(response):
         st.session_state.followup = True
         st.rerun()
     elif st.session_state.submit_request:
-        print(f"   ⚠️ Submit request but no response - resetting submit_request")
+        logger.warning("   ⚠️ Submit request but no response - resetting submit_request")
         st.session_state.submit_request = False
     else:
-        print(f"   ℹ️ No action taken (response: {response is not None}, submit_request: {st.session_state.submit_request}, followup: {st.session_state.followup})")
+        logger.info(
+            f"   ℹ️ No action taken (response: {response is not None}, submit_request: {st.session_state.submit_request}, followup: {st.session_state.followup})"
+        )
 
 
 def main():

--- a/MAS/app/streamlit_experimental_session.py
+++ b/MAS/app/streamlit_experimental_session.py
@@ -9,6 +9,7 @@ import os
 import sys
 import json
 import random
+import logging
 import streamlit as st
 from datetime import datetime
 from typing import Dict, List, Any, Optional
@@ -33,6 +34,9 @@ except ImportError:
     from utils.openai_api import OpenAIManager
     from utils.logging_utils import SessionLogger
     from utils.mermaid_parser import MermaidParser
+
+logger = logging.getLogger(__name__)
+
 
 class StreamlitExperimentalSession:
     """Manages a complete interactive experimental session through Streamlit."""
@@ -270,9 +274,9 @@ class StreamlitExperimentalSession:
         session_timing = {}
         
         # Debug logging - always log for troubleshooting
-        print(f"🔍 DEBUG: Converting concept map data")
-        print(f"   Input type: {type(streamlit_cm_data).__name__}")
-        print(f"   Input data: {str(streamlit_cm_data)[:200] if streamlit_cm_data else 'None'}")
+        logger.info("🔍 DEBUG: Converting concept map data")
+        logger.info(f"   Input type: {type(streamlit_cm_data).__name__}")
+        logger.info(f"   Input data: {str(streamlit_cm_data)[:200] if streamlit_cm_data else 'None'}")
         
         if self.session_logger:
             self.session_logger.log_event(
@@ -287,49 +291,49 @@ class StreamlitExperimentalSession:
         
         # Handle different input types
         if streamlit_cm_data is None:
-            print("   ⚠️  Input is None - returning empty structure")
+            logger.warning("   ⚠️  Input is None - returning empty structure")
             # Return empty structure for None input
             pass
         elif isinstance(streamlit_cm_data, str):
-            print("   📝 Input is string - attempting JSON parse")
+            logger.info("   📝 Input is string - attempting JSON parse")
             # Handle string input (might be JSON or initial map format)
             try:
                 if streamlit_cm_data.strip():
                     parsed_data = json.loads(streamlit_cm_data)
                     if isinstance(parsed_data, dict):
                         streamlit_cm_data = parsed_data
-                        print(f"   ✅ Successfully parsed JSON: {len(parsed_data)} keys")
+                        logger.info(f"   ✅ Successfully parsed JSON: {len(parsed_data)} keys")
                     else:
                         # If it's not a valid dict after parsing, treat as empty
                         streamlit_cm_data = {}
-                        print("   ⚠️  Parsed data is not a dict")
+                        logger.warning("   ⚠️  Parsed data is not a dict")
                 else:
                     streamlit_cm_data = {}
-                    print("   ⚠️  Empty string input")
+                    logger.warning("   ⚠️  Empty string input")
             except (json.JSONDecodeError, AttributeError) as e:
                 # If JSON parsing fails, treat as empty concept map
                 streamlit_cm_data = {}
-                print(f"   ❌ JSON parsing failed: {e}")
+                logger.error(f"   ❌ JSON parsing failed: {e}")
         elif not isinstance(streamlit_cm_data, dict):
-            print(f"   ⚠️  Input is not dict, string, or None: {type(streamlit_cm_data)}")
+            logger.warning(f"   ⚠️  Input is not dict, string, or None: {type(streamlit_cm_data)}")
             # If it's not a dict, string, or None, treat as empty
             streamlit_cm_data = {}
         
         # Process the data if it's now a dictionary
         if isinstance(streamlit_cm_data, dict):
-            print(f"   📊 Processing dict with keys: {list(streamlit_cm_data.keys())}")
+            logger.info(f"   📊 Processing dict with keys: {list(streamlit_cm_data.keys())}")
             
             # Extract action history and metrics if available (enhanced format)
             action_history = streamlit_cm_data.get("action_history", [])
             interaction_metrics = streamlit_cm_data.get("interaction_metrics", {})
             session_timing = streamlit_cm_data.get("session_timing", {})
             
-            print(f"   📈 Found {len(action_history)} actions, metrics: {bool(interaction_metrics)}")
+            logger.info(f"   📈 Found {len(action_history)} actions, metrics: {bool(interaction_metrics)}")
             
             # Process concept map elements
             if "elements" in streamlit_cm_data:
                 elements = streamlit_cm_data["elements"]
-                print(f"   🗺️  Processing {len(elements)} elements")
+                logger.info(f"   🗺️  Processing {len(elements)} elements")
                 
                 if self.session_logger:
                     self.session_logger.log_event(
@@ -342,15 +346,15 @@ class StreamlitExperimentalSession:
                 
                 for i, element in enumerate(elements):
                     if not isinstance(element, dict):
-                        print(f"   ⚠️  Element {i} is not a dict: {type(element)}")
+                        logger.warning(f"   ⚠️  Element {i} is not a dict: {type(element)}")
                         continue
                     
                     if "data" not in element:
-                        print(f"   ⚠️  Element {i} has no 'data' key: {list(element.keys())}")
+                        logger.warning(f"   ⚠️  Element {i} has no 'data' key: {list(element.keys())}")
                         continue
                         
                     data = element.get("data", {})
-                    print(f"   🔍 Element {i} data: {data}")
+                    logger.info(f"   🔍 Element {i} data: {data}")
                     
                     # Check if it's a node (has id but no source/target)
                     if "id" in data and "source" not in data and "target" not in data:
@@ -361,7 +365,7 @@ class StreamlitExperimentalSession:
                             "y": data.get("y", 0)
                         }
                         concepts.append(concept)
-                        print(f"   ✅ Added node: {concept}")
+                        logger.info(f"   ✅ Added node: {concept}")
                         
                         if self.session_logger:
                             self.session_logger.log_event(
@@ -378,7 +382,7 @@ class StreamlitExperimentalSession:
                             "text": data.get("label", "")
                         }
                         relationships.append(relationship)
-                        print(f"   ✅ Added edge: {relationship}")
+                        logger.info(f"   ✅ Added edge: {relationship}")
                         
                         if self.session_logger:
                             self.session_logger.log_event(
@@ -386,9 +390,9 @@ class StreamlitExperimentalSession:
                                 metadata={"edge": relationship}
                             )
                     else:
-                        print(f"   ⚠️  Element {i} is neither node nor edge: {data}")
+                        logger.warning(f"   ⚠️  Element {i} is neither node nor edge: {data}")
             else:
-                print("   ⚠️  No 'elements' key found in data")
+                logger.warning("   ⚠️  No 'elements' key found in data")
         
         result = {
             "concepts": concepts,
@@ -400,7 +404,7 @@ class StreamlitExperimentalSession:
             "source_format": "streamlit_enhanced"
         }
         
-        print(f"   🎯 Final result: {len(concepts)} concepts, {len(relationships)} relationships")
+        logger.info(f"   🎯 Final result: {len(concepts)} concepts, {len(relationships)} relationships")
         
         # Final debug log
         if self.session_logger:


### PR DESCRIPTION
## Summary
- Replace print statements in concept map handlers with module loggers to capture debug activity in log files
- Add logging setup in `app.py` and `streamlit_experimental_session.py` so node and edge creation events are recorded

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68930f0efd8483228c9dc1d902df01b2