### PR TITLE
Ensure concept map debug logs are saved to session log file

### DIFF
--- a/MAS/app/app.py
+++ b/MAS/app/app.py
@@ -1,9 +1,13 @@
 import json
 import os
 import copy
+import logging
 import streamlit as st
 from conceptmap_component import conceptmap_component, parse_conceptmap
 from streamlit_experimental_session import StreamlitExperimentalSession
+
+
+logger = logging.getLogger(__name__)
 
 
 # Session State Initialization
@@ -593,25 +597,34 @@ def render_followup():
 def handle_response(response):
     """Handle concept map response with cumulative logic and enhanced debugging."""
     # Always log what we receive, even if None
-    print(f"🔍 HANDLE_RESPONSE DEBUG:")
-    print(f"   Response received: {response is not None}")
-    print(f"   Response type: {type(response).__name__}")
-    print(f"   Followup state: {st.session_state.followup}")
-    print(f"   Submit request: {st.session_state.submit_request}")
+    logger.debug("🔍 HANDLE_RESPONSE DEBUG:")
+    logger.debug(f"   Response received: {response is not None}")
+    logger.debug(f"   Response type: {type(response).__name__}")
+    logger.debug(f"   Followup state: {st.session_state.followup}")
+    logger.debug(f"   Submit request: {st.session_state.submit_request}")
 
     if response is not None:
-        print(f"   Response content: {str(response)[:300]}")
+        logger.debug(f"   Response content: {str(response)[:300]}")
         if isinstance(response, dict):
-            print(f"   Has elements: {'elements' in response}")
+            logger.debug(f"   Has elements: {'elements' in response}")
             if "elements" in response:
-                print(f"   Elements count: {len(response['elements'])}")
+                logger.debug(f"   Elements count: {len(response['elements'])}")
 
     # --- Real-time logging of node and edge creations ---
     if response and isinstance(response, dict) and "elements" in response:
         elements = response["elements"]
-        dict_elements = [e for e in elements if isinstance(e, dict)]
-        current_nodes = {e["data"]["id"] for e in dict_elements if "source" not in e.get("data", {})}
-        current_edges = {e["data"]["id"] for e in dict_elements if "source" in e.get("data", {})}
+        if isinstance(elements, dict):
+            dict_elements = []
+            dict_elements.extend(elements.get("nodes", []))
+            dict_elements.extend(elements.get("edges", []))
+        else:
+            dict_elements = [e for e in elements if isinstance(e, dict)]
+        current_nodes = {
+            e["data"]["id"] for e in dict_elements if "source" not in e.get("data", {})
+        }
+        current_edges = {
+            e["data"]["id"] for e in dict_elements if "source" in e.get("data", {})
+        }
 
         prev_nodes = st.session_state.get("_prev_cm_nodes")
         prev_edges = st.session_state.get("_prev_cm_edges")
@@ -633,7 +646,7 @@ def handle_response(response):
                     for e in dict_elements
                     if e.get("data", {}).get("id") == node_id
                 )
-                print(
+                logger.info(
                     f"🆕 Node created: {node_data.get('label', '')} (id: {node_id}, x: {node_data.get('x')}, y: {node_data.get('y')})"
                 )
                 if (
@@ -656,7 +669,7 @@ def handle_response(response):
                     for e in dict_elements
                     if e.get("data", {}).get("id") == edge_id
                 )
-                print(
+                logger.info(
                     f"🆕 Edge created: {edge_data.get('source')} -> {edge_data.get('target')} "
                     f"(label: {edge_data.get('label', '')}, id: {edge_id})"
                 )
@@ -679,7 +692,7 @@ def handle_response(response):
             st.session_state._prev_cm_edges = current_edges
     
     if st.session_state.submit_request and response and not st.session_state.followup:
-        print(f"   ✅ Processing response...")
+        logger.info("   ✅ Processing response...")
         
         # Debug: Log what we received
         if st.session_state.experimental_session and st.session_state.experimental_session.session_logger:
@@ -709,7 +722,7 @@ def handle_response(response):
         
         # Update the current round's concept map with the new data
         st.session_state.cmdata[roundn] = response
-        print(f"   📝 Stored response in cmdata[{roundn}]")
+        logger.info(f"   📝 Stored response in cmdata[{roundn}]")
         
         # Debug: Show what we're storing
         if isinstance(response, dict) and "elements" in response:
@@ -738,10 +751,12 @@ def handle_response(response):
         st.session_state.followup = True
         st.rerun()
     elif st.session_state.submit_request:
-        print(f"   ⚠️ Submit request but no response - resetting submit_request")
+        logger.warning("   ⚠️ Submit request but no response - resetting submit_request")
         st.session_state.submit_request = False
     else:
-        print(f"   ℹ️ No action taken (response: {response is not None}, submit_request: {st.session_state.submit_request}, followup: {st.session_state.followup})")
+        logger.info(
+            f"   ℹ️ No action taken (response: {response is not None}, submit_request: {st.session_state.submit_request}, followup: {st.session_state.followup})"
+        )
 
 
 def main():


### PR DESCRIPTION
## Summary
- Normalize concept map `elements` handling in `handle_response` to detect node and edge additions whether data is a dict or list
- Update `StreamlitExperimentalSession.convert_streamlit_to_internal_format` to process dict-based element structures so node and edge processing logs appear in session files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68930f0efd8483228c9dc1d902df01b2